### PR TITLE
add tilemap.Flags enum, flags optional, fix tests

### DIFF
--- a/sappho/tilemap.py
+++ b/sappho/tilemap.py
@@ -14,6 +14,11 @@ PY3 = sys.version_info[0] == 3
 range = range if PY3 else xrange
 
 
+class Flags(object):
+    SOLID_BLOCK = "solid_block"
+    AUTO_MASK = "auto_mask"
+
+
 class Tile(pygame.sprite.Sprite):
     """A tile object is a sprite, which is typically
     a subsurface of a tilesheet.
@@ -29,11 +34,11 @@ class Tile(pygame.sprite.Sprite):
 
     """
 
-    def __init__(self, id_, image, flags):
+    def __init__(self, id_, image, flags=None):
         super(Tile, self).__init__()
         self.id_ = id_
         self.image = image
-        self.flags = flags
+        self.flags = flags or set([])
 
 
 class Tilesheet(object):
@@ -218,7 +223,7 @@ class TileMap(object):
 
             for x, tile in enumerate(row_of_tiles):
                 
-                if "solid_block" in tile.flags:
+                if Flags.SOLID_BLOCK in tile.flags:
                     left_top = (x * self.tilesheet.tile_size[0],
                                 y * self.tilesheet.tile_size[1])
                     block = pygame.rect.Rect(left_top,

--- a/tests/test_tilemap.py
+++ b/tests/test_tilemap.py
@@ -13,7 +13,8 @@ class TestTile(object):
         tile = sappho.tilemap.Tile(0, surface)
 
         assert(tile.id_ == 0)
-        assert(tile.solid_block == False) # default is False so check that
+        assert(len(tile.flags) == 0)
+        assert(isinstance(tile.flags, set))
 
 
 class TestTilesheet(object):
@@ -27,7 +28,8 @@ class TestTilesheet(object):
         tilesheet = sappho.tilemap.Tilesheet.from_file(path, 1, 1)
 
         # Test that tile rules are loaded correctly
-        assert(tilesheet.tiles[0].solid_block == True)
+        assert(sappho.tilemap.Flags.SOLID_BLOCK in
+               tilesheet.tiles[0].flags)
 
     def test_subsurface(self):
         testpath = os.path.realpath(__file__)
@@ -59,11 +61,11 @@ class TestTilesheet(object):
 
         rules = sappho.tilemap.Tilesheet.parse_rules(path)
         
-        assert(rules[0] == ['solid_block'])
-        assert(rules[1] == ['solid_block'])
-        assert(rules[2] == ['solid_block'])
-        assert(rules[3] == ['solid_block'])
-        assert(rules[4] == ['solid_block'])
+        assert(rules[0] == set([sappho.tilemap.Flags.SOLID_BLOCK]))
+        assert(rules[1] == set([sappho.tilemap.Flags.SOLID_BLOCK]))
+        assert(rules[2] == set([sappho.tilemap.Flags.SOLID_BLOCK]))
+        assert(rules[3] == set([sappho.tilemap.Flags.SOLID_BLOCK]))
+        assert(rules[4] == set([sappho.tilemap.Flags.SOLID_BLOCK]))
 
 
 class TestTilemap(object):


### PR DESCRIPTION
Instead of testing `if "solid_block" in flags` you'll
now do something like `if tilemap.Flags.SOLID_BLOCK in flags`,
this is to avoid typo/errors, complications, bugs.

Update the tests so they reflect recent changes, especially
those API changes to the tilemap.

Make Tile's flag argument optional (constructor).